### PR TITLE
Change build to be triggered on PR

### DIFF
--- a/.github/workflows/build-gradle-project.yml
+++ b/.github/workflows/build-gradle-project.yml
@@ -1,6 +1,6 @@
 name: Build and test
 
-on: [push]
+on: [pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
This PR changes the build job to be triggered on PR instead of on push. 